### PR TITLE
support vscode-comment-translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can install it from [**here**](https://wata.github.io/konjac-farm/).
 
 ![feature configure](images/feature-configure.gif)
 
+- This extension also functions as a translation source for the [Comment Translate extension](https://marketplace.visualstudio.com/items?itemName=intellsmi.comment-translate) .
+
 ## Extension Settings
 
 This extension contributes the following settings:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
         "@vscode/test-electron": "^1.6.2",
+        "comment-translate-manager": "^0.0.5",
         "eslint": "^8.1.0",
         "glob": "^7.2.0",
         "mocha": "^9.2.2",
@@ -158,9 +159,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+      "version": "1.83.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+      "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -706,6 +707,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comment-translate-manager": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/comment-translate-manager/-/comment-translate-manager-0.0.5.tgz",
+      "integrity": "sha512-3vSVYeAIiN9m+dCoEDdD8Sd58GhvnjWerE9QpgEySxQ3YNlof5ytPh4Bu9236kaaOJNdNCCd82VqVWffPQb/Mw==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/vscode": "^1.63.0"
       }
     },
     "node_modules/concat-map": {
@@ -2417,11 +2427,11 @@
       }
     },
     "node_modules/request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dependencies": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.19"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -2431,12 +2441,12 @@
       }
     },
     "node_modules/request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dependencies": {
-        "request-promise-core": "1.1.2",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       },
@@ -2693,7 +2703,7 @@
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2776,9 +2786,9 @@
       }
     },
     "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -3183,9 +3193,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-      "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+      "version": "1.83.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
+      "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -3563,6 +3573,13 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comment-translate-manager": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/comment-translate-manager/-/comment-translate-manager-0.0.5.tgz",
+      "integrity": "sha512-3vSVYeAIiN9m+dCoEDdD8Sd58GhvnjWerE9QpgEySxQ3YNlof5ytPh4Bu9236kaaOJNdNCCd82VqVWffPQb/Mw==",
+      "dev": true,
+      "requires": {}
     },
     "concat-map": {
       "version": "0.0.1",
@@ -4908,19 +4925,19 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "requires": {
-        "request-promise-core": "1.1.2",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
@@ -5039,7 +5056,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -5101,9 +5118,9 @@
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+          "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
   "activationEvents": [
     "*"
   ],
+  "keywords": [
+    "translate",
+    "google translate",
+    "translateSource",
+    "konjac"
+  ],
   "icon": "icon.png",
   "main": "./out/extension.js",
   "contributes": {
@@ -82,7 +88,13 @@
           "command": "konjac.setclipboard"
         }
       ]
-    }
+    },
+    "translates": [
+      {
+        "translate": "konjac",
+        "title": "Konjac translate"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -99,6 +111,7 @@
     "@types/node": "16.x",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
+    "comment-translate-manager": "^0.0.5",
     "eslint": "^8.1.0",
     "glob": "^7.2.0",
     "mocha": "^9.2.2",

--- a/src/KonjacTranslate.ts
+++ b/src/KonjacTranslate.ts
@@ -1,0 +1,27 @@
+import type { ITranslate, ITranslateOptions } from "comment-translate-manager";
+import { konjacFetch } from "./konjacFetch";
+import * as vscode from 'vscode';
+
+/** konjac for comment-translate-manager */
+export class KonjacTranslate implements ITranslate{
+  maxLen: number = 3000;
+  translate(content: string, options: ITranslateOptions): Promise<string> {
+    const apiUrl = vscode.workspace.getConfiguration('konjac')['apiUrl'];
+    if (!apiUrl) {
+      return Promise.reject(new Error('Go to user settings and edit "konjac.apiUrl".'));
+    }
+    return konjacFetch({
+      apiUrl: apiUrl,
+      text: content,
+      target: options.to,
+      source: options.from,
+    });
+  }
+  link(content: string, { to='auto',from='auto' }: ITranslateOptions): string {
+    const text = encodeURIComponent(content).replace(/[()]/g, (char) => `%${char.charCodeAt(0).toString(16)}`);
+    return `[Konjac](https://translate.google.com/?op=translate&sl=${from}&tl=${to}&text=${text})`;
+  }
+  isSupported(): boolean {
+    return true;
+  }
+};

--- a/src/konjacFetch.ts
+++ b/src/konjacFetch.ts
@@ -1,0 +1,42 @@
+const rp = require('request-promise-native');
+const encodeUrl = require('encodeurl');
+
+/**
+ * translate text using Konjac API
+ * @returns 
+ */
+export function konjacFetch({
+  text,
+  apiUrl,
+  target,
+  source,
+}: {
+  /** text to translate */
+  text: string;
+  /** api url of konjac */
+  apiUrl: string;
+  /** target language */
+  target?: string;
+  /** source language */
+  source?: string;
+}): Promise<string> {
+  const formData : Partial<Record<"source"|"target"|"text", string>> = { text };
+  if(source && source !== "auto") { formData.source = source; }
+  if(target && target !== "auto") { formData.target = target; }
+  const opts: any = {
+      uri: encodeUrl(apiUrl),
+      method: 'POST',
+      json: true,
+      followAllRedirects: true,
+      formData,
+      transform2xxOnly: true,
+      transform: function (body: any) {
+          // Google Apps Script Execution API always returns 200
+          if (!body.data) {
+              throw new Error(body.message);
+          }
+          return body.data.translatedText;
+      }
+  };
+  return rp(opts).then((result: unknown) => String(result));
+}


### PR DESCRIPTION
This change allows this extension to act as a translation source for Comment Translate.
Comment Tralslate is a vscode extension that includes a language parser and can remove decorated strings from comments in your code and translate them.

<img width="798" alt="image" src="https://github.com/wata/vscode-konjac/assets/18655/c25dfa02-c119-4502-9faf-2a4ea3774dca">

<img width="843" alt="image" src="https://github.com/wata/vscode-konjac/assets/18655/da024f58-156b-41c9-9e0c-5ccc661961c3">

see https://github.com/intellism/vscode-comment-translate

